### PR TITLE
Fix missing Config_git.pl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,3 +128,4 @@ target_link_libraries(test PRIVATE exiftool)
 # Install dll and headers
 install(TARGETS exiftool EXPORT exiftool)
 install(FILES exiftool.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${PERL_PREFIX}/lib/Config_git.pl DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Note: the failing macos build seems to be from GitHub's runners updating to XCode 15. We're still building with 14 so we should be fine once we actually build this in topaz-conan-src.